### PR TITLE
[BIG-3] Enable compiler optimizations for release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ BIN_DIR     := ./bin
 
 .PHONY: build_release
 
+
 build_release:
 	GOOS=linux go build -a -gccgoflags "-march=native -O3" -compiler gccgo -o ${BIN_DIR}/ ./lib/connector/src/*.go
 


### PR DESCRIPTION
[BIG-3] Enable compiler optimizations for release builds

Сборка программы через gccgo с оптимизациями производится так:
go build -compiler gccgo -gccgoflags "-march=native -O3" main.go

См.
https://habr.com/ru/post/222957/ 

[BIG-3]: https://konstantinfiglovsky.atlassian.net/browse/BIG-3